### PR TITLE
[CHORE] [JNII-45] @CurrentMember 어노테이션을 활용한 유저 정보 취득 방식 변경

### DIFF
--- a/src/main/java/com/mcphub/domain/member/converter/RoleConverter.java
+++ b/src/main/java/com/mcphub/domain/member/converter/RoleConverter.java
@@ -2,7 +2,7 @@ package com.mcphub.domain.member.converter;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
-import com.mcphub.domain.member.entity.enums.Role;
+import com.mcphub.global.config.security.auth.enums.Role;
 
 @Converter(autoApply = true)
 public class RoleConverter implements AttributeConverter<Role, Integer> {

--- a/src/main/java/com/mcphub/domain/member/converter/response/MemberConverter.java
+++ b/src/main/java/com/mcphub/domain/member/converter/response/MemberConverter.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component;
 import com.mcphub.domain.member.dto.response.member.auth.MemberLoginResponse;
 import com.mcphub.domain.member.dto.response.member.common.MemberIdResponse;
 import com.mcphub.domain.member.entity.Member;
-import com.mcphub.domain.member.entity.enums.Role;
+import com.mcphub.global.config.security.auth.enums.Role;
 import com.mcphub.domain.member.entity.enums.Status;
 import com.mcphub.global.config.security.jwt.TokenInfo;
 

--- a/src/main/java/com/mcphub/domain/member/dto/response/member/auth/MemberLoginResponse.java
+++ b/src/main/java/com/mcphub/domain/member/dto/response/member/auth/MemberLoginResponse.java
@@ -1,6 +1,6 @@
 package com.mcphub.domain.member.dto.response.member.auth;
 
-import com.mcphub.domain.member.entity.enums.Role;
+import com.mcphub.global.config.security.auth.enums.Role;
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/mcphub/domain/member/entity/Member.java
+++ b/src/main/java/com/mcphub/domain/member/entity/Member.java
@@ -2,7 +2,7 @@ package com.mcphub.domain.member.entity;
 
 import com.mcphub.domain.member.converter.RoleConverter;
 import com.mcphub.domain.member.entity.enums.LoginType;
-import com.mcphub.domain.member.entity.enums.Role;
+import com.mcphub.global.config.security.auth.enums.Role;
 import com.mcphub.domain.member.entity.enums.Status;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/mcphub/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/mcphub/global/config/security/SecurityConfig.java
@@ -3,7 +3,7 @@ package com.mcphub.global.config.security;
 import org.springframework.http.MediaType;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import com.mcphub.domain.member.entity.enums.Role;
+import com.mcphub.global.config.security.auth.enums.Role;
 import com.mcphub.domain.member.service.member.MemberService;
 import com.mcphub.global.config.security.auth.CustomAccessDeniedHandler;
 import com.mcphub.global.config.security.jwt.JwtAuthenticationFilter;

--- a/src/main/java/com/mcphub/global/config/security/auth/PrincipalDetails.java
+++ b/src/main/java/com/mcphub/global/config/security/auth/PrincipalDetails.java
@@ -1,6 +1,7 @@
 package com.mcphub.global.config.security.auth;
 
 import com.mcphub.domain.member.entity.Member;
+import com.mcphub.global.config.security.auth.dto.AuthMember;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
@@ -15,7 +16,7 @@ import java.util.Collection;
 @Getter
 @AllArgsConstructor // 생성자를 만들어줌
 public class PrincipalDetails implements UserDetails {
-    private Member member;
+    private AuthMember member;
     public BCryptPasswordEncoder encodePwd() {
         return new BCryptPasswordEncoder();
     }

--- a/src/main/java/com/mcphub/global/config/security/auth/dto/AuthMember.java
+++ b/src/main/java/com/mcphub/global/config/security/auth/dto/AuthMember.java
@@ -1,0 +1,13 @@
+package com.mcphub.global.config.security.auth.dto;
+
+import com.mcphub.global.config.security.auth.enums.Role;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class AuthMember {
+    private Long id;
+    private Role role;
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/mcphub/global/config/security/auth/enums/Role.java
+++ b/src/main/java/com/mcphub/global/config/security/auth/enums/Role.java
@@ -1,7 +1,5 @@
-package com.mcphub.domain.member.entity.enums;
+package com.mcphub.global.config.security.auth.enums;
 
-import jakarta.persistence.AttributeConverter;
-import jakarta.persistence.Converter;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 


### PR DESCRIPTION
## 💼 Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [x] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 📚 PR Desciption

> 변경 사항 설명

- AuthMember 라는 DTO 클래스를 global.config.security.auth 디렉토리에 생성하여, @CurrentMember 에 사용되는 Member 클래스를 대체

- PrincipalDetails 의 Member 클래스를 AuthMember 클래스로 변경

- Member 클래스에 사용되는 Role 클래스를 global.config.security.auth 디렉토리로 리팩토링

## 🪐 Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 

## 🛰️ 관련 이슈

- close #
